### PR TITLE
fix: fix f1 score in evaluate dataset

### DIFF
--- a/src/evalmyai/_evalmyai.py
+++ b/src/evalmyai/_evalmyai.py
@@ -524,8 +524,13 @@ class Evaluator:
                     retry_cnt=retry_cnt,
                 )
                 for symbol in res:
-                    scores[symbol].append(res[symbol]["scores"]["score"])
                     reasons[symbol].append(res[symbol]["reasoning"])
+                    if symbol == "f1":
+                        scores[symbol].append({"f1": res[symbol]["scores"]["f1"],
+                                               "correctness": res[symbol]["scores"]["correctness"],
+                                               "completeness": res[symbol]["scores"]["completeness"]})
+                    else:
+                        scores[symbol].append(res[symbol]["scores"]["score"])
                 errors.append(None)
             except requests.exceptions.HTTPError as e:
                 for symbol in symbols:


### PR DESCRIPTION
Fixes evaluate dataset for f1 score by returning f1 scores as a dict containing f1, correctness and completeness.

Before this fix, f1 score in evaluate_dataset threw a key error because f1 score does not have ["score"] key but it contains "f1", "correctness" and "completeness".